### PR TITLE
add name generation functionality

### DIFF
--- a/DiscordBot/Modules/NameModule.cs
+++ b/DiscordBot/Modules/NameModule.cs
@@ -1,0 +1,33 @@
+﻿using Discord;
+using Discord.Interactions;
+using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace DiscordBot.Modules
+{
+    public class NameModule : InteractionModuleBase<SocketInteractionContext>
+    {
+        private IConfiguration _config;
+
+        public NameModule(IConfiguration config)
+        {
+            _config = config;
+        }
+
+        [SlashCommand("generate-name", "Generate a name to be used in a video game. Pick the game, and the object you want a name for.")]
+        public async Task GenerateName(string game, string item)
+        {
+            // To be finished once API is published.
+            //var channel = Context.Channel.Name;
+            //var user = Context.User.Username;
+            //var url = _config.GetValue<string>("BaseAPIUrl");
+            //var apiService = new DemAPI.Client(url, new HttpClient())
+            //{
+            //    ReadResponseAsString = true
+            //};
+            //var reply = await apiService.ApiCardsDeleteAsync(channel, user, target?.Username);
+            //await RespondAsync(reply);
+        }
+    }
+}

--- a/MiscTwitchChat/Controllers/AI/NameController.cs
+++ b/MiscTwitchChat/Controllers/AI/NameController.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Summary description for Class1
+/// </summary>
+[Route("api/ai/[controller]")]
+[ApiController]
+public class NameController : ControllerBase
+{
+    private readonly string _apiKey;
+    private readonly string _baseUrl;
+
+    public NameController()
+    {
+        _apiKey = Environment.GetEnvironmentVariable("OPEN_AI_KEY");
+        _baseUrl = Environment.GetEnvironmentVariable("OPEN_AI_URL");
+        if (string.IsNullOrEmpty(_apiKey) || string.IsNullOrEmpty(_baseUrl))
+        {
+            throw new InvalidOperationException("API key or base URL is not set in environment variables.");
+        }
+    }
+
+    [HttpGet("{game}/{item}")]
+    public async Task<string> GetAsync(string game, string item)
+    {
+        using HttpClient client = new HttpClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+        var prompt = $"Generate a short, casual, and punny name for a {item} within the game {game}. Say just the name, nothing else.";
+        var requestBody = new
+        {
+            model = "gpt-4",
+            messages = new[]
+            {
+                new { role = "system", content = "You are a helpful assistant. You will be asked to complete things related to certain video games. Provide only short answers, designed to be inserted into a livestream chat, like Twitch chat. Stay casual, but not insulting. Use puns whenever you can." },
+                new { role = "user", content = prompt }
+            },
+            max_tokens = 100
+        };
+
+        string jsonContent = JsonSerializer.Serialize(requestBody);
+        var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.PostAsync(_baseUrl, content);
+        if (!response.IsSuccessStatusCode)
+        {
+            return $"Error: {response.StatusCode} - {await response.Content.ReadAsStringAsync()}";
+        }
+
+        using var responseStream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(responseStream);
+
+        return doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString();
+    }
+}

--- a/MiscTwitchChat/Properties/launchSettings.json
+++ b/MiscTwitchChat/Properties/launchSettings.json
@@ -2,7 +2,6 @@
   "profiles": {
     "MiscTwitchChat": {
       "commandName": "Project",
-      "commandLineArgs": "",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
add name generation functionality

- Updated `launchSettings.json` to remove the `commandName` property from the `MiscTwitchChat` profile.
- Introduced `NameModule` in `NameModule.cs` with a slash command `GenerateName` for generating names based on game and item inputs.
- Added `NameController` in `NameController.cs` to handle HTTP GET requests for name generation, utilizing environment variables for API key and base URL, and implementing error handling for API responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new Discord slash command to generate creative names based on game and item inputs.
  - Rolled out an API endpoint that retrieves engaging, pun-inspired name suggestions using AI.

- **Chores**
  - Updated the development configuration by removing unnecessary command-line arguments for a cleaner launch experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->