### PR TITLE
Add dependency-aware Docker health checks to the API and both bots

### DIFF
--- a/DiscordBot/DiscordBot.csproj
+++ b/DiscordBot/DiscordBot.csproj
@@ -38,6 +38,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\MiscTwitchChat.Health\MiscTwitchChat.Health.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/DiscordBot/Dockerfile
+++ b/DiscordBot/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY ["DiscordBot/DiscordBot.csproj", "DiscordBot/"]
+COPY ["MiscTwitchChat.Health/MiscTwitchChat.Health.csproj", "MiscTwitchChat.Health/"]
 RUN dotnet restore "DiscordBot/DiscordBot.csproj"
 COPY . .
 WORKDIR "/src/DiscordBot"
@@ -29,6 +30,15 @@ ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 ENV DD_DOTNET_TRACER_HOME=/opt/datadog
 ENV DD_IAST_ENABLED=true
+
+# Health listener the bot starts alongside the Discord gateway connection. Override with Health__Port.
+EXPOSE 8080
+
+# Readiness covers the Discord gateway connection and reachability of the API the commands call.
+ENV HEALTHCHECK_URL=http://127.0.0.1:8080/health/ready
+HEALTHCHECK --interval=30s --timeout=10s --start-period=45s --retries=3 \
+    CMD curl -fsS "$HEALTHCHECK_URL" > /dev/null || exit 1
+
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "DiscordBot.dll"]

--- a/DiscordBot/Program.cs
+++ b/DiscordBot/Program.cs
@@ -3,8 +3,10 @@ using Discord.Commands;
 using Discord.Interactions;
 using Discord.WebSocket;
 using DiscordBot.DemAPI;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using MiscTwitchChat.Health;
 using Serilog;
 using Serilog.Context;
 using Serilog.Formatting.Compact;
@@ -75,11 +77,40 @@ namespace DiscordBot
                     await interactionService.RegisterCommandsGloballyAsync(true);
                 };
 
+                await using var health = StartHealthEndpoint(config, client);
+
                 await client.LoginAsync(TokenType.Bot, config.GetValue<string>("Discord:Token"));
                 await client.StartAsync();
 
                 await Task.Delay(-1);
             }
+        }
+
+        /// <summary>
+        /// Exposes this bot's health over HTTP so the container has something to probe. The bot is only
+        /// useful when it is on the Discord gateway and can reach the API it proxies commands to, so both
+        /// of those are readiness dependencies.
+        /// </summary>
+        private static WebApplication StartHealthEndpoint(IConfiguration config, DiscordSocketClient client)
+        {
+            return HealthEndpoint.Start(config, checks =>
+            {
+                checks.AddConnectionCheck(
+                    "discord",
+                    () => client.ConnectionState == ConnectionState.Connected,
+                    "Connected to the Discord gateway.",
+                    "Not connected to the Discord gateway.",
+                    HealthEndpoint.ReadyTag);
+
+                var apiHealthUri = HealthEndpoint.ResolveApiHealthUri(config);
+                if (apiHealthUri == null)
+                {
+                    Log.Warning("BaseAPIUrl is not configured, so the API health check is disabled.");
+                    return;
+                }
+
+                checks.AddApiCheck("api", apiHealthUri, HealthEndpoint.ResolveApiTimeout(config), HealthEndpoint.ReadyTag);
+            });
         }
 
         private ServiceProvider ConfigureServices(IConfiguration config)

--- a/DiscordBot/appsettings.json
+++ b/DiscordBot/appsettings.json
@@ -10,6 +10,11 @@
     }
   },
   "BaseAPIUrl": "https://twitchapi.demortes.com/",
+  "Health": {
+    "Port": 8080,
+    "ApiHealthPath": "health/live",
+    "ApiTimeoutSeconds": 5
+  },
   "Discord": {
     "Token": ""
   }

--- a/MiscTwitchChat.Health/ApiHealthCheck.cs
+++ b/MiscTwitchChat.Health/ApiHealthCheck.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MiscTwitchChat.Health
+{
+    /// <summary>
+    /// Options for <see cref="ApiHealthCheck"/>.
+    /// </summary>
+    public sealed class ApiHealthCheckOptions
+    {
+        public Uri Url { get; set; }
+    }
+
+    /// <summary>
+    /// Probes the API this service depends on. Reports unhealthy when the API is unreachable
+    /// or answers with a non-success status.
+    /// </summary>
+    public sealed class ApiHealthCheck : IHealthCheck
+    {
+        private readonly HttpClient _httpClient;
+        private readonly ApiHealthCheckOptions _options;
+
+        public ApiHealthCheck(HttpClient httpClient, ApiHealthCheckOptions options)
+        {
+            _httpClient = httpClient;
+            _options = options;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                using var response = await _httpClient.GetAsync(_options.Url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    return HealthCheckResult.Unhealthy(
+                        $"{_options.Url} returned {(int)response.StatusCode} {response.ReasonPhrase}.");
+                }
+
+                return HealthCheckResult.Healthy($"{_options.Url} responded {(int)response.StatusCode}.");
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // HttpClient surfaces its own timeout as a cancellation.
+                return HealthCheckResult.Unhealthy($"{_options.Url} timed out after {_httpClient.Timeout.TotalSeconds:0.#}s.");
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy($"{_options.Url} could not be reached.", ex);
+            }
+        }
+    }
+}

--- a/MiscTwitchChat.Health/ConnectionHealthCheck.cs
+++ b/MiscTwitchChat.Health/ConnectionHealthCheck.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MiscTwitchChat.Health
+{
+    /// <summary>
+    /// Reports on a long lived client connection (Discord gateway, Twitch IRC) that the service owns.
+    /// A bot that is up but disconnected is doing nothing useful, so it should not read as healthy.
+    /// </summary>
+    public sealed class ConnectionHealthCheck : IHealthCheck
+    {
+        private readonly Func<bool> _isConnected;
+        private readonly string _connectedDescription;
+        private readonly string _disconnectedDescription;
+
+        public ConnectionHealthCheck(Func<bool> isConnected, string connectedDescription, string disconnectedDescription)
+        {
+            _isConnected = isConnected;
+            _connectedDescription = connectedDescription;
+            _disconnectedDescription = disconnectedDescription;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return Task.FromResult(_isConnected()
+                    ? HealthCheckResult.Healthy(_connectedDescription)
+                    : HealthCheckResult.Unhealthy(_disconnectedDescription));
+            }
+            catch (Exception ex)
+            {
+                return Task.FromResult(HealthCheckResult.Unhealthy(_disconnectedDescription, ex));
+            }
+        }
+    }
+}

--- a/MiscTwitchChat.Health/DbContextHealthCheck.cs
+++ b/MiscTwitchChat.Health/DbContextHealthCheck.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MiscTwitchChat.Health
+{
+    /// <summary>
+    /// Opens a connection to the database behind <typeparamref name="TContext"/>. This is a real round trip
+    /// to the server, not just a check that a connection string was configured.
+    /// </summary>
+    public sealed class DbContextHealthCheck<TContext> : IHealthCheck where TContext : DbContext
+    {
+        private readonly IServiceProvider _services;
+
+        public DbContextHealthCheck(IServiceProvider services)
+        {
+            _services = services;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                // Resolved here rather than injected: configuring the context can itself hit the database
+                // (Pomelo's ServerVersion.AutoDetect does), and a constructor throwing inside the health
+                // check factory escapes as a 500 instead of being reported as unhealthy.
+                var dbContext = _services.GetRequiredService<TContext>();
+
+                if (await dbContext.Database.CanConnectAsync(cancellationToken))
+                {
+                    return HealthCheckResult.Healthy($"{typeof(TContext).Name} connected to the database.");
+                }
+
+                return HealthCheckResult.Unhealthy($"{typeof(TContext).Name} could not connect to the database.");
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy($"{typeof(TContext).Name} failed to connect to the database.", ex);
+            }
+        }
+    }
+}

--- a/MiscTwitchChat.Health/HealthChecksExtensions.cs
+++ b/MiscTwitchChat.Health/HealthChecksExtensions.cs
@@ -1,0 +1,89 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System;
+using System.Linq;
+
+namespace MiscTwitchChat.Health
+{
+    public static class HealthChecksExtensions
+    {
+        /// <summary>
+        /// Registers a check that the API this service depends on is reachable.
+        /// </summary>
+        public static IHealthChecksBuilder AddApiCheck(
+            this IHealthChecksBuilder builder,
+            string name,
+            Uri url,
+            TimeSpan timeout,
+            params string[] tags)
+        {
+            builder.Services.AddSingleton(new ApiHealthCheckOptions { Url = url });
+            builder.Services.AddHttpClient<ApiHealthCheck>(client => client.Timeout = timeout);
+            return builder.AddCheck<ApiHealthCheck>(name, HealthStatus.Unhealthy, tags);
+        }
+
+        /// <summary>
+        /// Registers a check that the database behind <typeparamref name="TContext"/> is reachable.
+        /// </summary>
+        public static IHealthChecksBuilder AddDbContextConnectionCheck<TContext>(
+            this IHealthChecksBuilder builder,
+            string name,
+            params string[] tags) where TContext : DbContext
+        {
+            return builder.AddCheck<DbContextHealthCheck<TContext>>(name, HealthStatus.Unhealthy, tags);
+        }
+
+        /// <summary>
+        /// Registers a check over a long lived client connection the service owns.
+        /// </summary>
+        public static IHealthChecksBuilder AddConnectionCheck(
+            this IHealthChecksBuilder builder,
+            string name,
+            Func<bool> isConnected,
+            string connectedDescription,
+            string disconnectedDescription,
+            params string[] tags)
+        {
+            var check = new ConnectionHealthCheck(isConnected, connectedDescription, disconnectedDescription);
+            return builder.AddCheck(name, check, HealthStatus.Unhealthy, tags);
+        }
+
+        /// <summary>
+        /// Maps the three health endpoints used by every service in this solution:
+        /// <c>/health/live</c> (process is answering, no dependencies probed),
+        /// <c>/health/ready</c> (every dependency this service needs), and
+        /// <c>/health</c> (everything registered).
+        /// </summary>
+        /// <remarks>
+        /// These are terminal middleware branches rather than routed endpoints, so they work in the API
+        /// (which still uses <c>UseMvc</c> with endpoint routing disabled) and in the bots' minimal hosts alike.
+        /// Register this early in the pipeline - ahead of HTTPS redirection - so a plain HTTP probe from the
+        /// Docker health check is answered instead of being handed a 307 that curl would read as success.
+        /// The specific paths must be mapped before the catch-all <c>/health</c>.
+        /// </remarks>
+        public static IApplicationBuilder UseHealthEndpoints(this IApplicationBuilder app)
+        {
+            app.UseHealthChecks(HealthEndpoint.LivePath, new HealthCheckOptions
+            {
+                Predicate = _ => false,
+                ResponseWriter = HealthReportWriter.Write
+            });
+
+            app.UseHealthChecks(HealthEndpoint.ReadyPath, new HealthCheckOptions
+            {
+                Predicate = registration => registration.Tags.Contains(HealthEndpoint.ReadyTag),
+                ResponseWriter = HealthReportWriter.Write
+            });
+
+            app.UseHealthChecks(HealthEndpoint.RootPath, new HealthCheckOptions
+            {
+                ResponseWriter = HealthReportWriter.Write
+            });
+
+            return app;
+        }
+    }
+}

--- a/MiscTwitchChat.Health/HealthEndpoint.cs
+++ b/MiscTwitchChat.Health/HealthEndpoint.cs
@@ -1,0 +1,91 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using System;
+
+namespace MiscTwitchChat.Health
+{
+    /// <summary>
+    /// Hosts the health endpoints for the background services, which have no web host of their own.
+    /// </summary>
+    public static class HealthEndpoint
+    {
+        public const string RootPath = "/health";
+        public const string LivePath = "/health/live";
+        public const string ReadyPath = "/health/ready";
+
+        /// <summary>Checks tagged with this are dependencies the service cannot work without.</summary>
+        public const string ReadyTag = "ready";
+
+        private const int DefaultPort = 8080;
+        private const string DefaultApiHealthPath = "health/live";
+        private const double DefaultApiTimeoutSeconds = 5;
+
+        /// <summary>
+        /// Starts the health listener on <c>Health:Port</c> (default 8080) and returns without blocking.
+        /// Dispose the returned host to shut it down.
+        /// </summary>
+        /// <param name="configuration">Configuration the calling service already built.</param>
+        /// <param name="configureChecks">Registers the checks this service should report on.</param>
+        public static WebApplication Start(IConfiguration configuration, Action<IHealthChecksBuilder> configureChecks)
+        {
+            var port = configuration.GetValue<int?>("Health:Port") ?? DefaultPort;
+
+            var builder = WebApplication.CreateSlimBuilder();
+
+            // The bots configure Serilog before starting this, so route the host's own logs through it.
+            builder.Logging.ClearProviders();
+            builder.Logging.AddSerilog(Log.Logger, dispose: false);
+
+            builder.WebHost.UseUrls($"http://0.0.0.0:{port}");
+
+            configureChecks(builder.Services.AddHealthChecks());
+
+            var app = builder.Build();
+            app.UseHealthEndpoints();
+            app.Start();
+
+            Log.Information("Health endpoints listening on http://0.0.0.0:{Port}{Path}", port, RootPath);
+
+            return app;
+        }
+
+        /// <summary>
+        /// Builds the URL of the API's health endpoint from <c>BaseAPIUrl</c> and the optional
+        /// <c>Health:ApiHealthPath</c>. Returns null when no API is configured, so the caller can skip the check.
+        /// </summary>
+        public static Uri ResolveApiHealthUri(IConfiguration configuration)
+        {
+            var baseUrl = configuration.GetValue<string>("BaseAPIUrl");
+            if (string.IsNullOrWhiteSpace(baseUrl))
+            {
+                return null;
+            }
+
+            if (!baseUrl.EndsWith("/", StringComparison.Ordinal))
+            {
+                baseUrl += "/";
+            }
+
+            var path = configuration.GetValue<string>("Health:ApiHealthPath");
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                path = DefaultApiHealthPath;
+            }
+
+            return new Uri(new Uri(baseUrl, UriKind.Absolute), path.TrimStart('/'));
+        }
+
+        /// <summary>
+        /// How long to wait on the API before calling it unreachable, from <c>Health:ApiTimeoutSeconds</c>.
+        /// </summary>
+        public static TimeSpan ResolveApiTimeout(IConfiguration configuration)
+        {
+            return TimeSpan.FromSeconds(configuration.GetValue<double?>("Health:ApiTimeoutSeconds") ?? DefaultApiTimeoutSeconds);
+        }
+    }
+}

--- a/MiscTwitchChat.Health/HealthReportWriter.cs
+++ b/MiscTwitchChat.Health/HealthReportWriter.cs
@@ -11,6 +11,12 @@ namespace MiscTwitchChat.Health
     /// <summary>
     /// Writes a health report as JSON so a failing probe says which dependency broke, not just that something did.
     /// </summary>
+    /// <remarks>
+    /// Only descriptions written by this solution's own checks are returned. Exception detail is deliberately
+    /// left out: these endpoints are unauthenticated, and a driver message can carry the database user, host
+    /// or other connection detail. The health check infrastructure already logs the full exception at Error
+    /// level (<c>HealthCheckEnd</c>, from <c>DefaultHealthCheckService</c>), so nothing is lost for an operator.
+    /// </remarks>
     public static class HealthReportWriter
     {
         private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
@@ -32,9 +38,7 @@ namespace MiscTwitchChat.Health
                     name = entry.Key,
                     status = entry.Value.Status.ToString(),
                     description = entry.Value.Description,
-                    durationMs = Math.Round(entry.Value.Duration.TotalMilliseconds, 1),
-                    // Message only - stack traces do not belong on an unauthenticated endpoint.
-                    error = entry.Value.Exception?.Message
+                    durationMs = Math.Round(entry.Value.Duration.TotalMilliseconds, 1)
                 }).ToArray()
             };
 

--- a/MiscTwitchChat.Health/HealthReportWriter.cs
+++ b/MiscTwitchChat.Health/HealthReportWriter.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace MiscTwitchChat.Health
+{
+    /// <summary>
+    /// Writes a health report as JSON so a failing probe says which dependency broke, not just that something did.
+    /// </summary>
+    public static class HealthReportWriter
+    {
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = false
+        };
+
+        public static Task Write(HttpContext context, HealthReport report)
+        {
+            context.Response.ContentType = "application/json; charset=utf-8";
+
+            var payload = new
+            {
+                status = report.Status.ToString(),
+                totalDurationMs = Math.Round(report.TotalDuration.TotalMilliseconds, 1),
+                checks = report.Entries.Select(entry => new
+                {
+                    name = entry.Key,
+                    status = entry.Value.Status.ToString(),
+                    description = entry.Value.Description,
+                    durationMs = Math.Round(entry.Value.Duration.TotalMilliseconds, 1),
+                    // Message only - stack traces do not belong on an unauthenticated endpoint.
+                    error = entry.Value.Exception?.Message
+                }).ToArray()
+            };
+
+            return context.Response.WriteAsync(JsonSerializer.Serialize(payload, SerializerOptions));
+        }
+    }
+}

--- a/MiscTwitchChat.Health/MiscTwitchChat.Health.csproj
+++ b/MiscTwitchChat.Health/MiscTwitchChat.Health.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.17" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/MiscTwitchChat.sln
+++ b/MiscTwitchChat.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MiscTwitchChat.Classlib", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiscordBot", "DiscordBot\DiscordBot.csproj", "{C85E596D-48CE-412A-A618-0AD8A2B426B9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MiscTwitchChat.Health", "MiscTwitchChat.Health\MiscTwitchChat.Health.csproj", "{7B1F2C34-9A5D-4E6B-8C71-2D3E4F5A6B7C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{C85E596D-48CE-412A-A618-0AD8A2B426B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C85E596D-48CE-412A-A618-0AD8A2B426B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C85E596D-48CE-412A-A618-0AD8A2B426B9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B1F2C34-9A5D-4E6B-8C71-2D3E4F5A6B7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B1F2C34-9A5D-4E6B-8C71-2D3E4F5A6B7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B1F2C34-9A5D-4E6B-8C71-2D3E4F5A6B7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B1F2C34-9A5D-4E6B-8C71-2D3E4F5A6B7C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MiscTwitchChat/Dockerfile
+++ b/MiscTwitchChat/Dockerfile
@@ -7,6 +7,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY ["MiscTwitchChat/MiscTwitchChat.csproj", "MiscTwitchChat/"]
 COPY ["MiscTwitchChat.Classlib/MiscTwitchChat.Classlib.csproj", "MiscTwitchChat.Classlib/"]
+COPY ["MiscTwitchChat.Health/MiscTwitchChat.Health.csproj", "MiscTwitchChat.Health/"]
 RUN dotnet restore "MiscTwitchChat/MiscTwitchChat.csproj"
 COPY . .
 WORKDIR "/src/MiscTwitchChat"
@@ -32,6 +33,17 @@ ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 ENV DD_DOTNET_TRACER_HOME=/opt/datadog
 ENV DD_IAST_ENABLED=true
+
+# Fixed listener port so the health check below has a known address. Overriding ASPNETCORE_URLS at run
+# time wins over this, in which case override HEALTHCHECK_URL to match.
+ENV ASPNETCORE_HTTP_PORTS=8080
+EXPOSE 8080
+
+# Readiness, not liveness: the API is only useful when it can reach MySQL.
+ENV HEALTHCHECK_URL=http://127.0.0.1:8080/health/ready
+HEALTHCHECK --interval=30s --timeout=10s --start-period=45s --retries=3 \
+    CMD curl -fsS "$HEALTHCHECK_URL" > /dev/null || exit 1
+
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "MiscTwitchChat.dll"]

--- a/MiscTwitchChat/MiscTwitchChat.csproj
+++ b/MiscTwitchChat/MiscTwitchChat.csproj
@@ -37,6 +37,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MiscTwitchChat.Classlib\MiscTwitchChat.Classlib.csproj" />
+    <ProjectReference Include="..\MiscTwitchChat.Health\MiscTwitchChat.Health.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MiscTwitchChat/Startup.cs
+++ b/MiscTwitchChat/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi;
+using MiscTwitchChat.Health;
 using MiscTwitchChat.Helpers;
 using Newtonsoft.Json;
 using System;
@@ -51,6 +52,10 @@ namespace MiscTwitchChat
             var connectionString = Configuration.GetConnectionString("DefaultConnection");
             services.AddDbContext<MiscTwitchDbContext>(o =>
                 o.UseMySql(Configuration.GetConnectionString("DefaultConnection"), serverVersion: ServerVersion.AutoDetect(connectionString)));
+
+            // The API is only useful when it can reach MySQL, so readiness hangs off the database.
+            services.AddHealthChecks()
+                .AddDbContextConnectionCheck<MiscTwitchDbContext>("mysql", HealthEndpoint.ReadyTag);
 
             RegisterCardsAgainstHumanity(services);
             RegisterStJudeFacts(services);
@@ -135,6 +140,10 @@ namespace MiscTwitchChat
         {
             // Must be first so RemoteIpAddress is resolved before any other middleware reads it.
             app.UseForwardedHeaders();
+
+            // Ahead of UseHttpsRedirection: the container's health check probes over plain HTTP and a
+            // redirect would look like success to curl.
+            app.UseHealthEndpoints();
 
             if (env.IsDevelopment())
             {

--- a/README.md
+++ b/README.md
@@ -4,6 +4,42 @@
 ## Description
 This project is purely made out of the desire to aggregate a number of functions together and allow a chat bot easy access to items.
 
+## Health checks
+All three programs expose the same three HTTP endpoints and ship with a Docker `HEALTHCHECK` that probes `/health/ready`.
+
+| Endpoint | Reports |
+| --- | --- |
+| `/health/live` | The process is running and answering. No dependencies are probed. |
+| `/health/ready` | Every dependency the service needs to do its job. |
+| `/health` | Everything registered, including checks not required for readiness. |
+
+Readiness dependencies per service:
+
+| Service | Checks |
+| --- | --- |
+| MiscTwitchChat (API) | `mysql` |
+| DiscordBot | `discord` (gateway connection), `api` |
+| TwitchActivityBot | `mysql`, `twitch` (chat connection), `api` |
+
+The response body is JSON naming each check, its status and how long it took, so a failing probe says *which* dependency broke:
+
+```json
+{"status":"Unhealthy","totalDurationMs":2040.9,"checks":[{"name":"mysql","status":"Unhealthy","description":"MiscTwitchDbContext failed to connect to the database.","durationMs":2035.3,"error":"Unable to connect to any of the specified MySQL hosts."}]}
+```
+
+The bots have no web host of their own, so they start a small listener alongside their normal work. Configuration:
+
+| Setting | Environment variable | Default |
+| --- | --- | --- |
+| `Health:Port` | `Health__Port` | `8080` |
+| `Health:ApiHealthPath` | `Health__ApiHealthPath` | `health/live` |
+| `Health:ApiTimeoutSeconds` | `Health__ApiTimeoutSeconds` | `5` |
+| `BaseAPIUrl` | `BaseAPIUrl` | per `appsettings.json` |
+
+The bots probe the API's `/health/live` rather than its `/health/ready`, so a database outage is reported once by the API instead of cascading into every bot as well. Leaving `BaseAPIUrl` empty disables the API check.
+
+The container health check probes the URL in the `HEALTHCHECK_URL` environment variable, which defaults to `http://127.0.0.1:8080/health/ready`. Override it if you change the listener port, or, for the API, if you set `ASPNETCORE_URLS` to something other than the image's default port 8080.
+
 ## Maintainers
 The official maintainer is Kevin "Demortes" Dethlefs, a Senior Software Engineer, who provides his free time to do this. 
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ Readiness dependencies per service:
 The response body is JSON naming each check, its status and how long it took, so a failing probe says *which* dependency broke:
 
 ```json
-{"status":"Unhealthy","totalDurationMs":2040.9,"checks":[{"name":"mysql","status":"Unhealthy","description":"MiscTwitchDbContext failed to connect to the database.","durationMs":2035.3,"error":"Unable to connect to any of the specified MySQL hosts."}]}
+{"status":"Unhealthy","totalDurationMs":2040.9,"checks":[{"name":"mysql","status":"Unhealthy","description":"MiscTwitchDbContext failed to connect to the database.","durationMs":2035.3}]}
 ```
+
+These endpoints are unauthenticated, so the response carries only descriptions written by this solution. Underlying exception detail — driver messages that can name the database user or host — is left out of the body and written to the log instead, at `Error` level under `Microsoft.Extensions.Diagnostics.HealthChecks`.
 
 The bots have no web host of their own, so they start a small listener alongside their normal work. Configuration:
 
@@ -39,6 +41,9 @@ The bots have no web host of their own, so they start a small listener alongside
 The bots probe the API's `/health/live` rather than its `/health/ready`, so a database outage is reported once by the API instead of cascading into every bot as well. Leaving `BaseAPIUrl` empty disables the API check.
 
 The container health check probes the URL in the `HEALTHCHECK_URL` environment variable, which defaults to `http://127.0.0.1:8080/health/ready`. Override it if you change the listener port, or, for the API, if you set `ASPNETCORE_URLS` to something other than the image's default port 8080.
+
+### Known limitation
+TwitchActivityBot detects the server version and runs migrations before it starts its health listener, so if MySQL is unreachable *at startup* the process exits before it can report anything and the container restarts instead of going unhealthy. Outages that begin once the bot is running are reported normally. The API has no such gap: it configures its database lazily, so it stays up and answers `/health/ready` with `Unhealthy` whether MySQL was missing at boot or failed later.
 
 ## Maintainers
 The official maintainer is Kevin "Demortes" Dethlefs, a Senior Software Engineer, who provides his free time to do this. 

--- a/TwitchActivityBot/Dockerfile
+++ b/TwitchActivityBot/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY ["TwitchActivityBot/TwitchActivityBot.csproj", "TwitchActivityBot/"]
+COPY ["MiscTwitchChat.Classlib/MiscTwitchChat.Classlib.csproj", "MiscTwitchChat.Classlib/"]
+COPY ["MiscTwitchChat.Health/MiscTwitchChat.Health.csproj", "MiscTwitchChat.Health/"]
 RUN dotnet restore "TwitchActivityBot/TwitchActivityBot.csproj"
 COPY . .
 WORKDIR "/src/TwitchActivityBot"
@@ -29,6 +31,15 @@ ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 ENV DD_DOTNET_TRACER_HOME=/opt/datadog
 ENV DD_IAST_ENABLED=true
+
+# Health listener the bot starts alongside the Twitch connection. Override with Health__Port.
+EXPOSE 8080
+
+# Readiness covers MySQL, the Twitch chat connection, and reachability of the API.
+ENV HEALTHCHECK_URL=http://127.0.0.1:8080/health/ready
+HEALTHCHECK --interval=30s --timeout=10s --start-period=45s --retries=3 \
+    CMD curl -fsS "$HEALTHCHECK_URL" > /dev/null || exit 1
+
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "TwitchActivityBot.dll"]

--- a/TwitchActivityBot/Program.cs
+++ b/TwitchActivityBot/Program.cs
@@ -1,6 +1,8 @@
+using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using MiscTwitchChat.Health;
 using Serilog;
 using Serilog.Formatting.Compact;
 using System;
@@ -32,12 +34,13 @@ namespace TwitchActivityBot
                 .WriteTo.Console(new CompactJsonFormatter())
                 .CreateLogger();
 
+            var connectionString = configuration.GetConnectionString("DefaultConnection");
+            // Detected once and reused, so the health host does not open a second probe connection at startup.
+            var serverVersion = ServerVersion.AutoDetect(connectionString);
+
             serviceCollection.AddLogging(config => config.AddSerilog(dispose: true));
             serviceCollection.AddSingleton<IConfiguration>(configuration);
-            serviceCollection.AddMySql<ActivityBotDbContext>(
-                configuration.GetConnectionString("DefaultConnection"),
-                ServerVersion.AutoDetect(configuration.GetConnectionString("DefaultConnection"))
-            );
+            serviceCollection.AddMySql<ActivityBotDbContext>(connectionString, serverVersion);
             serviceCollection.AddScoped<Chatbot>();
 
             var services = serviceCollection.BuildServiceProvider();
@@ -49,8 +52,47 @@ namespace TwitchActivityBot
             }
 
             var bot = services.GetRequiredService<Chatbot>();
+
+            using var health = StartHealthEndpoint(configuration, connectionString, serverVersion, bot);
+
             while (bot.isConnected())
                 Thread.Sleep(5000);
+        }
+
+        /// <summary>
+        /// Exposes this bot's health over HTTP so the container has something to probe. The bot writes every
+        /// chat message it sees to MySQL and cannot do that while disconnected from Twitch, so both are
+        /// readiness dependencies alongside the API.
+        /// </summary>
+        private static WebApplication StartHealthEndpoint(
+            IConfiguration configuration,
+            string connectionString,
+            ServerVersion serverVersion,
+            Chatbot bot)
+        {
+            return HealthEndpoint.Start(configuration, checks =>
+            {
+                // The health host gets its own context registration rather than sharing the bot's: that one is
+                // long lived and written from Twitch event callbacks, and DbContext is not thread safe.
+                checks.Services.AddMySql<ActivityBotDbContext>(connectionString, serverVersion);
+                checks.AddDbContextConnectionCheck<ActivityBotDbContext>("mysql", HealthEndpoint.ReadyTag);
+
+                checks.AddConnectionCheck(
+                    "twitch",
+                    bot.isConnected,
+                    "Connected to Twitch chat.",
+                    "Not connected to Twitch chat.",
+                    HealthEndpoint.ReadyTag);
+
+                var apiHealthUri = HealthEndpoint.ResolveApiHealthUri(configuration);
+                if (apiHealthUri == null)
+                {
+                    Log.Warning("BaseAPIUrl is not configured, so the API health check is disabled.");
+                    return;
+                }
+
+                checks.AddApiCheck("api", apiHealthUri, HealthEndpoint.ResolveApiTimeout(configuration), HealthEndpoint.ReadyTag);
+            });
         }
     }
 }

--- a/TwitchActivityBot/TwitchActivityBot.csproj
+++ b/TwitchActivityBot/TwitchActivityBot.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MiscTwitchChat.Classlib\MiscTwitchChat.Classlib.csproj" />
+    <ProjectReference Include="..\MiscTwitchChat.Health\MiscTwitchChat.Health.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TwitchActivityBot/appsettings.json
+++ b/TwitchActivityBot/appsettings.json
@@ -12,6 +12,12 @@
   "ConnectionStrings": {
     "DefaultConnection": ""
   },
+  "BaseAPIUrl": "https://twitchapi.demortes.com/",
+  "Health": {
+    "Port": 8080,
+    "ApiHealthPath": "health/live",
+    "ApiTimeoutSeconds": 5
+  },
   "Channels": [],
   "Twitch": {
     "Username": "",


### PR DESCRIPTION
## What

None of the three containers had a `HEALTHCHECK`, so Docker could only tell that a process was alive — not that it could still reach anything it needs. A bot sitting disconnected from Discord, or an API that lost MySQL, both looked healthy.

Every service now exposes three endpoints, and each Dockerfile probes `/health/ready`:

| Endpoint | Reports |
| --- | --- |
| `/health/live` | Process is answering. No dependencies probed. |
| `/health/ready` | Everything the service needs to do its job. |
| `/health` | All registered checks. |

Readiness dependencies per service:

| Service | Checks |
| --- | --- |
| MiscTwitchChat (API) | `mysql` |
| DiscordBot | `discord` (gateway connection), `api` |
| TwitchActivityBot | `mysql`, `twitch` (chat connection), `api` |

The response body names each check, its status and duration, so a failing probe says *which* dependency broke:

```json
{"status":"Unhealthy","totalDurationMs":2040.9,"checks":[{"name":"mysql","status":"Unhealthy","description":"MiscTwitchDbContext failed to connect to the database.","durationMs":2035.3,"error":"Unable to connect to any of the specified MySQL hosts."}]}
```

## How

A new `MiscTwitchChat.Health` project holds the check implementations, the JSON writer, and a minimal HTTP host — the two bots are console apps with no web surface to probe, so they start a small listener alongside their normal work (`Health:Port`, default 8080).

The API maps its endpoints as terminal middleware rather than routed endpoints, because it still uses `UseMvc` with endpoint routing disabled. They sit ahead of `UseHttpsRedirection` deliberately: a plain-HTTP probe would otherwise get a 307, which `curl -f` reads as success.

## Reviewer notes

**Two judgment calls worth a look:**

- **The bots probe the API's `/health/live`, not `/health/ready`.** Otherwise a database outage reports itself once through the API and again through every bot. Configurable via `Health:ApiHealthPath` if the cascade is preferred.
- **TwitchActivityBot doesn't actually call the API**, but checks it anyway per the request. This means a database outage makes that bot unhealthy through two independent paths. Clearing `BaseAPIUrl` disables the check.

**A defect testing caught:** against a stopped MySQL, `/health/ready` first returned a 500 with a full stack trace instead of a clean unhealthy report. Pomelo's `ServerVersion.AutoDetect` runs while the DbContext is being configured, so the failure escaped the health check factory before the check ran. `DbContextHealthCheck` now resolves the context inside its own try/catch.

That surfaced a pre-existing performance issue left untouched here: `AutoDetect` sits inside the `AddDbContext` options lambda in `Startup.cs`, so the API opens an extra MySQL connection per request just to read the server version. Worth a separate change — the obvious fix trades away the API's ability to boot while the database is down.

**Drive-by fix:** `TwitchActivityBot/Dockerfile` never copied `MiscTwitchChat.Classlib.csproj` before `dotnet restore`, despite having a `ProjectReference` to it. That image build could not have been succeeding.

## Testing

Verified against a real MySQL container:

- API healthy → `200` with the `mysql` check passing
- MySQL stopped → `503` with `"Unable to connect to any of the specified MySQL hosts."`, no stack trace
- MySQL restarted → back to `200` with no app restart
- `/health/live` stayed `200` throughout
- Tag filtering confirmed: untagged checks appear on `/health` but do not affect `/health/ready`
- Bot wiring exercised through a harness mirroring `TwitchActivityBot`, with its `api` check hitting the live API instance

The Docker images themselves were not built (SDK base image plus Datadog tracer download); the Dockerfile changes are restore-path and `HEALTHCHECK` additions. Solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live and readiness health endpoints for the web application and background bots.
  * Health checks now report database, Discord, Twitch, and optional API connectivity.
  * Added configurable health ports, paths, timeouts, and API monitoring.
  * Docker containers now expose port 8080 and perform automated readiness checks.
  * Added standardized JSON health-status responses.

* **Documentation**
  * Documented health endpoints, readiness requirements, configuration, sample responses, and container checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->