### PR TITLE
Pin MySQL server version instead of auto-detecting it on every request

### DIFF
--- a/MiscTwitchChat/Startup.cs
+++ b/MiscTwitchChat/Startup.cs
@@ -31,6 +31,11 @@ namespace MiscTwitchChat
             Configuration = builder.Build();
         }
 
+        /// <summary>
+        /// MySQL server version assumed when "Database:ServerVersion" is not configured. Currently the MySQL LTS release.
+        /// </summary>
+        private static readonly Version DefaultServerVersion = new(8, 4);
+
         private IConfiguration Configuration { get; }
 
         /// <summary>
@@ -50,8 +55,9 @@ namespace MiscTwitchChat
             });
             services.AddEntityFrameworkMySql();
             var connectionString = Configuration.GetConnectionString("DefaultConnection");
+            var serverVersion = ResolveServerVersion(Configuration);
             services.AddDbContext<MiscTwitchDbContext>(o =>
-                o.UseMySql(Configuration.GetConnectionString("DefaultConnection"), serverVersion: ServerVersion.AutoDetect(connectionString)));
+                o.UseMySql(connectionString, serverVersion));
 
             // The API is only useful when it can reach MySQL, so readiness hangs off the database.
             services.AddHealthChecks()
@@ -172,6 +178,36 @@ namespace MiscTwitchChat
                     name: "default",
                     template: "{controller=Home}/{action=Index}/{id?}");
             });
+        }
+
+        /// <summary>
+        /// Resolves the MySQL server version the EF Core provider targets for feature detection.
+        /// </summary>
+        /// <remarks>
+        /// The version is pinned from the "Database:ServerVersion" configuration value (for example "8.4") rather than
+        /// probed with <see cref="ServerVersion.AutoDetect(string)"/>. AutoDetect opens a throwaway connection to read
+        /// the version; inside the <c>AddDbContext</c> options lambda that ran once per scope, costing an extra
+        /// connection and round trip on every request. Pinning also keeps the application bootable when MySQL is
+        /// unreachable, so the endpoints that do not touch the database keep serving.
+        /// </remarks>
+        /// <param name="configuration">Configuration to read the pinned server version from.</param>
+        /// <returns>The configured server version, or <see cref="DefaultServerVersion"/> when none is configured.</returns>
+        /// <exception cref="InvalidOperationException">The configured value is not a parsable version.</exception>
+        private static ServerVersion ResolveServerVersion(IConfiguration configuration)
+        {
+            var configured = configuration["Database:ServerVersion"];
+            if (string.IsNullOrWhiteSpace(configured))
+            {
+                return new MySqlServerVersion(DefaultServerVersion);
+            }
+
+            if (!Version.TryParse(configured, out var parsed))
+            {
+                throw new InvalidOperationException(
+                    $"Configuration value 'Database:ServerVersion' ('{configured}') is not a valid version. Use a value such as '8.4'.");
+            }
+
+            return new MySqlServerVersion(parsed);
         }
 
         /// <summary>

--- a/MiscTwitchChat/Startup.cs
+++ b/MiscTwitchChat/Startup.cs
@@ -34,7 +34,7 @@ namespace MiscTwitchChat
         /// <summary>
         /// MySQL server version assumed when "Database:ServerVersion" is not configured. Currently the MySQL LTS release.
         /// </summary>
-        private static readonly Version DefaultServerVersion = new(8, 4);
+        private static readonly Version DefaultServerVersion = new(8, 4, 0);
 
         private IConfiguration Configuration { get; }
 
@@ -207,8 +207,19 @@ namespace MiscTwitchChat
                     $"Configuration value 'Database:ServerVersion' ('{configured}') is not a valid version. Use a value such as '8.4'.");
             }
 
-            return new MySqlServerVersion(parsed);
+            return new MySqlServerVersion(Normalize(parsed));
         }
+
+        /// <summary>
+        /// Expands a version to three components so provider feature gates compare as expected.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Version"/> leaves omitted components at -1, and -1 sorts below 0. That makes
+        /// <c>new Version(8, 4)</c> compare as *less than* <c>new Version(8, 4, 0)</c>, so a two-component
+        /// value silently fails any provider feature gated at exactly that release.
+        /// </remarks>
+        private static Version Normalize(Version version) =>
+            version.Build >= 0 ? version : new Version(version.Major, version.Minor, 0);
 
         /// <summary>
         /// Loads "cah_cards.json", deserializes it into a CAH_cards instance, and registers that instance as a singleton in the provided service collection.

--- a/MiscTwitchChat/appsettings.json
+++ b/MiscTwitchChat/appsettings.json
@@ -14,6 +14,9 @@
   "ConnectionStrings": {
     "DefaultConnection": ""
   },
+  "Database": {
+    "ServerVersion": "8.4"
+  },
   "ApplicationInsights": {
     "InstrumentationKey": "0045efbb-9f4c-4514-af85-47e07d1b2b14"
   }


### PR DESCRIPTION
## What

The API registered its `DbContext` like this:

```csharp
services.AddDbContext<MiscTwitchDbContext>(o =>
    o.UseMySql(Configuration.GetConnectionString("DefaultConnection"),
        serverVersion: ServerVersion.AutoDetect(connectionString)));
```

`ServerVersion.AutoDetect` was evaluated *inside* the options lambda. `AddDbContext` registers `DbContextOptions` with a scoped lifetime, so that lambda ran once per scope — per request — and each run opened a throwaway MySQL connection purely to read the server version. That was an extra connection and round trip on every request.

The version is now resolved once, outside the lambda, from a new `Database:ServerVersion` configuration value:

```csharp
var connectionString = Configuration.GetConnectionString("DefaultConnection");
var serverVersion = ResolveServerVersion(Configuration);
services.AddDbContext<MiscTwitchDbContext>(o =>
    o.UseMySql(connectionString, serverVersion));
```

The duplicate `GetConnectionString` call at the same site is gone too.

## Why pinning rather than hoisting

The other obvious fix is hoisting `AutoDetect` to a local before `AddDbContext`, matching what `TwitchActivityBot/Program.cs` does. That fixes the per-request cost but moves the probe to application startup, so the API would fail to boot whenever MySQL is unreachable.

Pinning avoids the connection entirely — none at request time, none at boot — which preserves two things worth keeping:

- **The API serves endpoints that never touch MySQL** (Cards Against Humanity, St. Jude facts, dictionary, urban dictionary). Fail-fast boot would take those down for a database outage they don't depend on.
- **`/health/ready` is the intended way to surface a database outage** (added in #205). Staying up and reporting unhealthy is more useful than a crash loop, and it's what the readiness probe was built to express.

`TwitchActivityBot` can afford fail-fast because it runs `db.Database.Migrate()` at startup and genuinely cannot function without the database. The API has no such dependency. I left that project alone — its call site already evaluates once at startup, so it doesn't have this bug.

## Configuration

`Database:ServerVersion` defaults to `8.4` (current MySQL LTS) when unset, and `appsettings.json` carries the key at that default so it's discoverable rather than a hidden lookup. An unparsable value throws at startup — that's a configuration error, which is a legitimate reason to fail fast, unlike an unreachable database.

## Reviewer notes

- **Confirm the pinned version matches your actual server.** Pomelo uses it for feature detection (JSON functions, generated columns, `LIMIT` handling), so a pin newer than the real server can produce SQL it rejects. I couldn't determine the deployed version from the repo — `DefaultConnection` is empty in `appsettings.json` and supplied via environment variables or user secrets, and the Dockerfiles don't stand up a MySQL service. If the deployment target isn't 8.4, set `Database__ServerVersion` in the environment config.
- **This assumes MySQL, not MariaDB.** `ResolveServerVersion` returns a `MySqlServerVersion`; a MariaDB target would need `MariaDbServerVersion` instead.
- **`MiscTwitchChat.Health/DbContextHealthCheck.cs` is deliberately untouched.** It resolves the `DbContext` inside a `try`/`catch` so a construction-time failure reports as Unhealthy rather than escaping as a 500. Its comment cites `ServerVersion.AutoDetect` as the motivating example, which this PR removes — but the defensive pattern still stands for any other construction failure, so the comment is mildly stale rather than wrong.

## Testing

`dotnet build MiscTwitchChat/MiscTwitchChat.csproj` succeeds with 0 errors. The 5 remaining warnings are all pre-existing on `main` — the NU1903 advisories for `Microsoft.OpenApi` and `Newtonsoft.Json`, and the `ForwardedHeadersOptions.KnownNetworks` deprecation.

Not verified against a live MySQL instance; no database was reachable from this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database startup reliability by using a configured MySQL server version.
  * Added MySQL 8.4 as the default database version.
  * Invalid database version settings now produce a clear configuration error.
* **Configuration**
  * Added support for overriding the MySQL server version through application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->