### PR TITLE
chore(deps): upgrade dependencies and fix two transitive CVEs

### DIFF
--- a/DiscordBot/DiscordBot.csproj
+++ b/DiscordBot/DiscordBot.csproj
@@ -8,31 +8,31 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="3.19.1" />
-    <PackageReference Include="Discord.Net.Commands" Version="3.19.1" />
-    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="10.0.9">
+    <PackageReference Include="Discord.Net" Version="3.20.1" />
+    <PackageReference Include="Discord.Net.Commands" Version="3.20.1" />
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NSwag.ApiDescription.Client" Version="14.7.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/MiscTwitchChat/MiscTwitchChat.csproj
+++ b/MiscTwitchChat/MiscTwitchChat.csproj
@@ -20,18 +20,20 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.9">
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <!-- Pinned directly to override the vulnerable 11.0.2 that UrbanDictionaryNet 1.0.3 pulls in transitively (GHSA-5crp-9r3c-p9vr). -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="UrbanDictionaryNet" Version="1.0.3" />
   </ItemGroup>
 

--- a/TwitchActivityBot/TwitchActivityBot.csproj
+++ b/TwitchActivityBot/TwitchActivityBot.csproj
@@ -17,19 +17,19 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="TwitchLib" Version="3.5.3" />
   </ItemGroup>


### PR DESCRIPTION
Clears the outstanding Dependabot version updates and resolves both high-severity transitive vulnerabilities that `dotnet restore` was reporting as `NU1903`.

## Security fixes

Both of these were **transitive**, so neither was visible in the `.csproj` files before this change.

| Package | Was | Now | Advisory |
|---|---|---|---|
| `Microsoft.OpenApi` | 2.4.1 | 2.7.5 | [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) (High) |
| `Newtonsoft.Json` | 11.0.2 | 13.0.4 | [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr) (High) |

- **Microsoft.OpenApi** comes in via Swashbuckle. Bumping `Swashbuckle.AspNetCore` 10.1.7 → 10.2.3 resolves `Microsoft.OpenApi` 2.7.5, which is exactly the first patched version for the advisory. No override needed.
- **Newtonsoft.Json** comes in via `UrbanDictionaryNet` 1.0.3, which is that package's newest release — there is no upstream fix. Overriding it with a direct `PackageReference` in `MiscTwitchChat.csproj` is the only available route. It has an inline comment explaining why, since it otherwise reads as an unused reference someone might "clean up" later.

## Version updates

- `Microsoft.Extensions.*` 10.0.9 → 10.0.10 (14 references across both bots)
- `Discord.Net` + `Discord.Net.Commands` 3.19.1 → 3.20.1
- `Serilog` 4.3.1 → 4.4.0
- `Serilog.Settings.Configuration` 10.0.0 → 10.0.1
- `Microsoft.Extensions.ApiDescription.Server` / `.Client` 10.0.9 → 10.0.10

## What reviewers should know: EF Core is deliberately held back

EF Core stays at **9.0.17**. Dependabot has two open PRs wanting 10.0.x (#197, #198) and **neither is mergeable.**

`Pomelo.EntityFrameworkCore.MySql` 9.0.0 hard-pins `Microsoft.EntityFrameworkCore.Relational` to `[9.0.0, 9.0.999]`, and 9.0.0 is Pomelo's newest release — there is no 10.x provider. I tested the bump rather than trusting the nuspec, and it produces:

> `NU1608: Pomelo.EntityFrameworkCore.MySql 9.0.0 requires Microsoft.EntityFrameworkCore.Relational (>= 9.0.0 && <= 9.0.999) but version Microsoft.EntityFrameworkCore.Relational 10.0.10 was resolved.`

That constraint propagates to `Classlib` and `Health` as well, since both feed projects that use Pomelo. **EF Core has to move as a single unit once Pomelo ships a 10.x provider** — #197 and #198 are safe to close.

The other three Dependabot PRs (#199, #202, #203) are already stale; they target 10.0.6 from older baselines and this branch goes past that to 10.0.10.

## Verification

- `dotnet restore --force-evaluate` — clean, no `NU1903` warnings
- `dotnet build -c Release` — **0 errors**
- `dotnet list package --vulnerable --include-transitive` — no vulnerable packages in any of the 5 projects
- `dotnet list package --outdated` — nothing left except the intentionally-held EF Core references

Two build warnings remain, both pre-existing and unrelated to dependencies: `ASPDEPR001` (the `ApiDescription.Client` package is deprecated upstream — I confirmed this warning is also present at 10.0.9) and `ASPDEPR005` on `ForwardedHeadersOptions.KnownNetworks` in `MiscTwitchChat/Startup.cs:102`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)